### PR TITLE
Fix GitHub App install return redirect flow

### DIFF
--- a/apps/main-site/src/app/(main-site)/_components/github-app-install-url.ts
+++ b/apps/main-site/src/app/(main-site)/_components/github-app-install-url.ts
@@ -1,0 +1,8 @@
+export function buildGitHubAppInstallUrl(
+	baseInstallUrl: string,
+	returnPath: string,
+) {
+	const installUrl = new URL(baseInstallUrl);
+	installUrl.searchParams.set("state", returnPath);
+	return installUrl.toString();
+}

--- a/apps/main-site/src/app/(main-site)/_components/install-github-app-button.tsx
+++ b/apps/main-site/src/app/(main-site)/_components/install-github-app-button.tsx
@@ -2,7 +2,8 @@
 
 import { Button } from "@packages/ui/components/button";
 import { Download } from "@packages/ui/components/icons";
-import type { ComponentProps } from "react";
+import { useEffect, useState, type ComponentProps } from "react";
+import { buildGitHubAppInstallUrl } from "./github-app-install-url";
 
 const GITHUB_APP_SLUG = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG ?? "";
 const GITHUB_APP_INSTALL_URL = GITHUB_APP_SLUG
@@ -27,12 +28,24 @@ export function InstallGitHubAppButton({
 		return null;
 	}
 
+	const [installHref, setInstallHref] = useState(GITHUB_APP_INSTALL_URL);
+
+	useEffect(() => {
+		const returnPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+		setInstallHref(buildGitHubAppInstallUrl(GITHUB_APP_INSTALL_URL, returnPath));
+	}, []);
+
 	return (
 		<Button asChild {...buttonProps}>
 			<a
-				href={GITHUB_APP_INSTALL_URL}
-				target="_blank"
-				rel="noopener noreferrer"
+				href={installHref}
+				onClick={(event) => {
+					const returnPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+					event.currentTarget.href = buildGitHubAppInstallUrl(
+						GITHUB_APP_INSTALL_URL,
+						returnPath,
+					);
+				}}
 			>
 				{!hideIcon && <Download className={iconClassName} />}
 				{children ?? "Install GitHub App"}

--- a/apps/main-site/src/app/github/setup/redirect-state.ts
+++ b/apps/main-site/src/app/github/setup/redirect-state.ts
@@ -1,0 +1,17 @@
+export function resolveSetupRedirectPath(state: string | null, requestUrl: URL) {
+	if (!state) return "/";
+
+	try {
+		if (state.startsWith("/") && !state.startsWith("//")) {
+			return state;
+		}
+
+		const candidate = new URL(state);
+		if (candidate.origin !== requestUrl.origin) {
+			return "/";
+		}
+		return `${candidate.pathname}${candidate.search}${candidate.hash}`;
+	} catch {
+		return "/";
+	}
+}

--- a/apps/main-site/src/app/github/setup/route.ts
+++ b/apps/main-site/src/app/github/setup/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { resolveSetupRedirectPath } from "./redirect-state";
 
 /**
  * GitHub App installation callback endpoint.
@@ -11,10 +12,11 @@ export async function GET(request: Request) {
 	const url = new URL(request.url);
 	const installationId = url.searchParams.get("installation_id");
 	const setupAction = url.searchParams.get("setup_action");
+	const redirectPath = resolveSetupRedirectPath(url.searchParams.get("state"), url);
 
 	if (!installationId || !setupAction) {
 		return NextResponse.redirect(new URL("/", request.url));
 	}
 
-	return NextResponse.redirect(new URL("/", request.url));
+	return NextResponse.redirect(new URL(redirectPath, request.url));
 }


### PR DESCRIPTION
## Summary
- preserve the in-app return path when opening GitHub App installation by setting `state`
- remove `_blank` install behavior so install flow stays in one tab
- validate callback `state` in `/github/setup` and only allow same-origin redirect targets
- fallback to `/` when callback params are missing or state is invalid

## Why
GitHub App installation could leave users on GitHub or return them to a generic page, which made setup look unsuccessful. This ensures users are redirected back to their original page in FasterGH after installation while preventing open redirect behavior.

## Testing
- not run locally in this environment (missing local dev binaries)
