### PR TITLE
fix(repo): track .env.example and add required local auth/env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Copy this file to .env and fill in real values.
+
+# Required: local app URL for Better Auth OAuth callbacks.
+SITE_URL=http://localhost:4007
+
+# Required: Convex deployment + endpoints.
+CONVEX_DEPLOYMENT=your-convex-deployment
+CONVEX_URL=https://your-deployment.convex.cloud
+CONVEX_SITE_URL=https://your-deployment.convex.site
+NEXT_PUBLIC_CONVEX_URL=https://your-deployment.convex.cloud
+
+# Required: auth secret used by Better Auth.
+# Generate with: openssl rand -base64 32
+BETTER_AUTH_SECRET=your-better-auth-secret
+
+# Required: GitHub OAuth ("Sign in with GitHub").
+GITHUB_APP_SLUG=your-github-app-slug
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+
+# Required: webhook signature verification.
+# Generate with: openssl rand -hex 32
+GITHUB_WEBHOOK_SECRET=your-github-webhook-secret
+
+# Optional: GitHub App installation-token auth path.
+# GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+
+# Optional: notifications OAuth provider.
+GITHUB_NOTIFICATIONS_CLIENT_ID=
+GITHUB_NOTIFICATIONS_CLIENT_SECRET=
+
+# Optional: observability values.
+# SENTRY_ORG=
+# SENTRY_PROJECT=
+# POSTHOG_KEY=
+# POSTHOG_HOST=https://us.i.posthog.com

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ yarn-error.log*
 temp-*
 
 *.env*
+!.env.example
 
 # eslint
 .eslintcache


### PR DESCRIPTION
This updates environment setup to match the README by committing a real .env.example template and unignoring it in .gitignore. The template is now required-first for local startup and GitHub sign-in, with optional values clearly marked so onboarding is clearer and less noisy.